### PR TITLE
fix: properly handle `<DEL>` alt alleles, error or warn on other `<>` alt alleles

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,8 @@ jobs:
           toolchain: stable
           override: true
           components: clippy
+      
+      - uses: Swatinem/rust-cache@v1.3.0
 
       - name: Lint with clippy
         uses: actions-rs/clippy-check@v1
@@ -66,6 +68,8 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - uses: Swatinem/rust-cache@v1.3.0
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+tests/output/**
+tests/resources/*.fa

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "microphaser"
-version = "0.2.0"
-authors = ["Jan Forster <jan.forster@uk-essen.de>", "Johannes Köster <johannes.koester@tu-dortmund.de>"]
+version = "0.5.0"
+authors = ["Jan Forster <jan.forster@uk-essen.de>", "Johannes Köster <johannes.koester@tu-dortmund.de>", "David Lähnemann <david.laehnemann@hhu.de>"]
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bio = "0.34"
 rust-htslib = "0.36"
-bio-types = "0.12.1"
+bio-types = "0.13"
 clap = { version = "2.27", features = ["yaml", "color", "suggestions"]}
 itertools = "0.10"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bio = "0.34"
 rust-htslib = "0.36"
-bio-types = "0.12"
+bio-types = "0.12.1"
 clap = { version = "2.27", features = ["yaml", "color", "suggestions"]}
 itertools = "0.10"
 log = "0.4"

--- a/src/build_ref_cli.yaml
+++ b/src/build_ref_cli.yaml
@@ -25,3 +25,7 @@ args:
       short: l
       default_value: "9"
       help: length of output peptides
+  - verbose:
+      long: verbose
+      short: v
+      help: Verbose output.

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,8 +6,10 @@ use bio_types::strand::Strand;
 use std::error::Error;
 use std::str;
 use std::str::FromStr;
+use itertools::Itertools;
 
-use rust_htslib::bcf;
+use rust_htslib::{bcf, bcf::record::Numeric};
+
 
 use std::borrow::ToOwned;
 
@@ -58,32 +60,102 @@ pub enum Variant {
 }
 
 impl Variant {
-    pub fn new(rec: &mut bcf::Record) -> Result<Vec<Self>, Box<dyn Error>> {
+    fn warn_or_error(msg: &str, unsupported_alleles_warning_only: bool) {
+        if unsupported_alleles_warning_only {
+            warn!("{}", msg)
+        } else {
+            error!("{}", msg)
+        }
+    }
+
+    pub fn new(rec: &mut bcf::Record, unsupported_alleles_warning_only: bool) -> Result<Vec<Self>, Box<dyn Error>> {
         let is_germline = !rec.info(b"SOMATIC").flag().unwrap_or(false);
 
         let ann = Annotation::new(rec);
 
         let prot_change = ann.prot_change.as_str();
+        let contig = rec.rid().ok_or_else(|| "Could not handle rec.rid().")?;
         let pos = rec.pos() as u64;
         let alleles = rec.alleles();
         let refallele = alleles[0];
         let mut _alleles = Vec::with_capacity(alleles.len() - 1);
         for a in &alleles[1..] {
             if a.len() == 1 && refallele.len() > 1 {
-                _alleles.push(Variant::Deletion {
-                    pos,
-                    len: (refallele.len() - 1) as u64,
-                    is_germline,
-                    prot_change: prot_change.to_owned(),
-                });
+                _alleles.push(
+                    Variant::Deletion {
+                        pos,
+                        len: (refallele.len() - 1) as u64,
+                        is_germline,
+                        prot_change: prot_change.to_owned(),
+                    }
+                );
             } else if a.len() > 1 && refallele.len() == 1 {
-                _alleles.push(Variant::Insertion {
-                    pos,
-                    seq: a[0..].to_owned(),
-                    len: (a.len() - 1) as u64,
-                    is_germline,
-                    prot_change: prot_change.to_owned(),
-                });
+                if a.starts_with(b"<") {
+                    if a == &("<DEL>".as_bytes()) {
+                        let err_msg: String;
+                        let svlen = match rec.info(b"SVLEN").integer() {
+                            Ok(Some(svlens)) => {
+                                let svlens = svlens
+                                    .iter()
+                                    .map(|l| {
+                                        if !l.is_missing() {
+                                            Some(l.abs() as u64)
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .collect_vec();
+                                if svlens.len() > 1 {
+                                    Err("microphaser does not handle multiallelic records. Please normalize, e.g. with `bcftools norm -m-`.")
+                                } else {
+                                    match svlens[0] {
+                                        Some(length) => Ok(length),
+                                        None => {
+                                            err_msg = format!("Found no 'SVLEN' info tag for <DEL> alternative allele on contig {contig} at pos {pos}");
+                                            Err(err_msg.as_str())
+                                        },
+                                    }
+                                }
+                            },
+                            Err(rust_htslib_error) => {
+                                err_msg = format!("Encountered rust_htslib error when trying to access 'SVLEN' tag for '<DEL>' alternative allele on contig {contig} at position {pos}: {rust_htslib_error}");
+                                Err(err_msg.as_str())
+                            },
+                            Ok(None) => {
+                                err_msg = format!("Found no 'SVLEN' info tag for <DEL> alternative allele at chr {contig} pos {pos}");
+                                Err(err_msg.as_str())
+                            },
+                        };
+                        match svlen {
+                            Ok(l) => {
+                                _alleles.push(
+                                    Variant::Deletion {
+                                        pos,
+                                        len: l,
+                                        is_germline,
+                                        prot_change: prot_change.to_owned(),
+                                    }
+                                );
+                            },
+                            Err(msg) => Variant::warn_or_error(msg, unsupported_alleles_warning_only),
+                        };
+                    } else {
+                        Variant::warn_or_error(
+                            format!("Alternative allele type '{a:?}' not yet supported, but found on contig {contig} at position {pos}. Please open a respective pull request or issue at https://github.com/koesterlab/microphaser").as_str(),
+                            unsupported_alleles_warning_only
+                        )
+                    }
+                } else {
+                    _alleles.push(
+                        Variant::Insertion {
+                            pos,
+                            seq: a[0..].to_owned(),
+                            len: (a.len() - 1) as u64,
+                            is_germline,
+                            prot_change: prot_change.to_owned(),
+                        }
+                    );
+                }
             } else if a.len() == 1 && refallele.len() == 1 {
                 _alleles.push(Variant::SNV {
                     pos,

--- a/src/germline_cli.yaml
+++ b/src/germline_cli.yaml
@@ -38,3 +38,9 @@ args:
       short: w
       default_value: "27"
       help: Length of generated haplotypes.
+  - unsupported-alleles-warning-only:
+      long: unsupported-allele-warning-only
+      short: u
+      help: When encountering an unsupported allele, microphaser currently
+        throws an errors and exits. To skip unsupported alleles with only a
+        warning, instead, please set this flag.

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,9 @@ pub fn run_somatic(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         .from_path(matches.value_of("tsv").unwrap())?;
     debug!("Start");
     let window_len = value_t!(matches, "window-len", u64)?;
+
+    let unsupported_alleles_warning_only = matches.is_present("unsupported-alleles-warning-only");
+
     microphasing::phase(
         &mut fasta_reader,
         &mut gtf_reader,
@@ -95,6 +98,7 @@ pub fn run_somatic(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         &mut tsv_writer,
         &mut normal_writer,
         window_len,
+        unsupported_alleles_warning_only,
     )
 }
 
@@ -125,6 +129,9 @@ pub fn run_normal(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         .from_path(matches.value_of("tsv").unwrap())?;
 
     let window_len = value_t!(matches, "window-len", u64)?;
+
+    let unsupported_alleles_warning_only = matches.is_present("unsupported-alleles-warning-only");
+
     normal_microphasing::phase(
         &mut fasta_reader,
         &mut gtf_reader,
@@ -133,6 +140,7 @@ pub fn run_normal(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         &mut tsv_writer,
         &mut fasta_writer,
         window_len,
+        unsupported_alleles_warning_only,
     )
 }
 
@@ -233,6 +241,9 @@ pub fn run_wg(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         .from_path(matches.value_of("tsv").unwrap())?;
 
     let window_len = value_t!(matches, "window-len", u64)?;
+
+    let unsupported_alleles_warning_only = matches.is_present("unsupported-alleles-warning-only");
+
     microphasing_wholegenome::phase(
         &mut fasta_reader,
         bcf_reader,
@@ -242,6 +253,7 @@ pub fn run_wg(matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
         &mut normal_writer,
         window_len,
         only_relevant,
+        unsupported_alleles_warning_only,
     )
 }
 

--- a/src/microphasing.rs
+++ b/src/microphasing.rs
@@ -933,7 +933,12 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
         variant_buffer.fetch(&gene.chrom.as_bytes(), gene.start(), gene.end())?;
     let _vars = variant_buffer
         .iter_mut()
-        .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec, unsupported_alleles_warning_only).unwrap()))
+        .map(|rec| {
+            variant_tree.insert(
+                rec.pos() as u64,
+                Variant::new(rec, unsupported_alleles_warning_only).unwrap(),
+            )
+        })
         .collect_vec();
 
     for transcript in &gene.transcripts {

--- a/src/microphasing.rs
+++ b/src/microphasing.rs
@@ -889,6 +889,7 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
     normal_writer: &mut fasta::Writer<fs::File>,
     window_len: u64,
     refseq: &mut Vec<u8>,
+    unsupported_alleles_warning_only: bool,
 ) -> Result<(), Box<dyn Error>> {
     // if an exon is near to the gene end, a deletion could cause refseq to overflow, so we increase the length of refseq
     let end_overflow = 100;
@@ -932,7 +933,7 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
         variant_buffer.fetch(&gene.chrom.as_bytes(), gene.start(), gene.end())?;
     let _vars = variant_buffer
         .iter_mut()
-        .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec).unwrap()))
+        .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec, unsupported_alleles_warning_only).unwrap()))
         .collect_vec();
 
     for transcript in &gene.transcripts {
@@ -1943,6 +1944,7 @@ pub fn phase<F: io::Read + io::Seek, G: io::Read, O: io::Write>(
     tsv_writer: &mut csv::Writer<fs::File>,
     normal_writer: &mut fasta::Writer<fs::File>,
     window_len: u64,
+    unsupported_alleles_warning_only: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut read_buffer = bam::RecordBuffer::new(bam_reader, false);
     debug!("Read Buffer Length {}", read_buffer.len());
@@ -1966,6 +1968,7 @@ pub fn phase<F: io::Read + io::Seek, G: io::Read, O: io::Write>(
                     normal_writer,
                     window_len,
                     &mut refseq,
+                    unsupported_alleles_warning_only,
                 )?;
             }
         }

--- a/src/microphasing_wholegenome.rs
+++ b/src/microphasing_wholegenome.rs
@@ -522,7 +522,12 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
             variant_buffer.fetch(&sequence.name.as_bytes(), chunk, chunk + 1000000)?;
         let _vars = variant_buffer
             .iter_mut()
-            .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec, unsupported_alleles_warning_only).unwrap()))
+            .map(|rec| {
+                variant_tree.insert(
+                    rec.pos() as u64,
+                    Variant::new(rec, unsupported_alleles_warning_only).unwrap(),
+                )
+            })
             .collect_vec();
 
         let mut observations = ObservationMatrix::new();

--- a/src/microphasing_wholegenome.rs
+++ b/src/microphasing_wholegenome.rs
@@ -489,6 +489,7 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
     window_len: u64,
     refseq: &mut Vec<u8>,
     only_relevant: bool,
+    unsupported_alleles_warning_only: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut chunk = 0;
     while chunk < sequence.len - 1000000 {
@@ -521,7 +522,7 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
             variant_buffer.fetch(&sequence.name.as_bytes(), chunk, chunk + 1000000)?;
         let _vars = variant_buffer
             .iter_mut()
-            .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec).unwrap()))
+            .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec, unsupported_alleles_warning_only).unwrap()))
             .collect_vec();
 
         let mut observations = ObservationMatrix::new();
@@ -779,6 +780,7 @@ pub fn phase<F: io::Read + io::Seek, O: io::Write>(
     normal_writer: &mut fasta::Writer<fs::File>,
     window_len: u64,
     only_relevant: bool,
+    unsupported_alleles_warning_only: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut read_buffer = bam::RecordBuffer::new(bam_reader, false);
     let mut variant_buffer = bcf::buffer::RecordBuffer::new(bcf_reader);
@@ -797,6 +799,7 @@ pub fn phase<F: io::Read + io::Seek, O: io::Write>(
             window_len,
             &mut refseq,
             only_relevant,
+            unsupported_alleles_warning_only,
         )?;
     }
     Ok(())

--- a/src/normal_microphasing.rs
+++ b/src/normal_microphasing.rs
@@ -689,7 +689,12 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
         variant_buffer.fetch(&gene.chrom.as_bytes(), gene.start(), gene.end())?;
     let _vars = variant_buffer
         .iter_mut()
-        .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec, unsupported_alleles_warning_only).unwrap()))
+        .map(|rec| {
+            variant_tree.insert(
+                rec.pos() as u64,
+                Variant::new(rec, unsupported_alleles_warning_only).unwrap(),
+            )
+        })
         .collect_vec();
 
     for transcript in &gene.transcripts {

--- a/src/normal_microphasing.rs
+++ b/src/normal_microphasing.rs
@@ -656,6 +656,7 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
     fasta_writer: &mut fasta::Writer<O>,
     window_len: u64,
     refseq: &mut Vec<u8>,
+    unsupported_alleles_warning_only: bool,
 ) -> Result<(), Box<dyn Error>> {
     // if an exon is near to the gene end, a deletion could cause refseq to overflow, so we increase the length of refseq
     let end_overflow = 100;
@@ -688,7 +689,7 @@ pub fn phase_gene<F: io::Read + io::Seek, O: io::Write>(
         variant_buffer.fetch(&gene.chrom.as_bytes(), gene.start(), gene.end())?;
     let _vars = variant_buffer
         .iter_mut()
-        .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec).unwrap()))
+        .map(|rec| variant_tree.insert(rec.pos() as u64, Variant::new(rec, unsupported_alleles_warning_only).unwrap()))
         .collect_vec();
 
     for transcript in &gene.transcripts {
@@ -1280,6 +1281,7 @@ pub fn phase<F: io::Read + io::Seek, G: io::Read, O: io::Write>(
     tsv_writer: &mut csv::Writer<fs::File>,
     fasta_writer: &mut fasta::Writer<O>,
     window_len: u64,
+    unsupported_alleles_warning_only: bool,
 ) -> Result<(), Box<dyn Error>> {
     let mut read_buffer = bam::RecordBuffer::new(bam_reader, false);
     let mut variant_buffer = bcf::buffer::RecordBuffer::new(bcf_reader);
@@ -1300,6 +1302,7 @@ pub fn phase<F: io::Read + io::Seek, G: io::Read, O: io::Write>(
                     fasta_writer,
                     window_len,
                     &mut refseq,
+                    unsupported_alleles_warning_only,
                 )?;
             }
         }

--- a/src/somatic_cli.yaml
+++ b/src/somatic_cli.yaml
@@ -42,3 +42,9 @@ args:
       value_name: FILE
       default_value: "normal.fasta"
       help: Output wildtype haplotypes of mutated sequences.
+  - unsupported-alleles-warning-only:
+      long: unsupported-allele-warning-only
+      short: u
+      help: When encountering an unsupported allele, microphaser currently
+        throws an errors and exits. To skip unsupported alleles with only a
+        warning, instead, please set this flag.

--- a/src/wgs.yaml
+++ b/src/wgs.yaml
@@ -45,3 +45,9 @@ args:
       value_name: FILE
       default_value: "normal.fasta"
       help: Output wildtype haplotypes of mutated sequences.
+  - unsupported-alleles-warning-only:
+      long: unsupported-allele-warning-only
+      short: u
+      help: When encountering an unsupported allele, microphaser currently
+        throws an errors and exits. To skip unsupported alleles with only a
+        warning, instead, please set this flag.


### PR DESCRIPTION
The respective code now also throws a proper error message when encountering an unknown `<>`-style alternative allele. And the newly introduced flag `--unsupported-alleles-warning-only` (or `-u` for short) allows downgrading this error to a warning. With this turned on, microphaser will run through when encountering such unknown alleles, simply by skipping them. But with the default behaviour, we will always at first see an unsupported allele type, even in workflows, so that we can fix it.